### PR TITLE
PDF attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ $pdf->output();
 - [Circles and ellipses](doc/tuto_8.md)
 - [Rotation](doc/tuto_9.md)
 - [Sector](doc/tuto_10.md)
+- [Attachments](doc/tuto_11.md)
 
 ## Code Quality
 

--- a/composer.lock
+++ b/composer.lock
@@ -715,16 +715,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.2",
+            "version": "11.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "153d0531b9f7e883c5053160cad6dd5ac28140b3"
+                "reference": "30e319e578a7b5da3543073e30002bf82042f701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/153d0531b9f7e883c5053160cad6dd5ac28140b3",
-                "reference": "153d0531b9f7e883c5053160cad6dd5ac28140b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/30e319e578a7b5da3543073e30002bf82042f701",
+                "reference": "30e319e578a7b5da3543073e30002bf82042f701",
                 "shasum": ""
             },
             "require": {
@@ -745,7 +745,7 @@
                 "phpunit/php-timer": "^7.0.1",
                 "sebastian/cli-parser": "^3.0.2",
                 "sebastian/code-unit": "^3.0.2",
-                "sebastian/comparator": "^6.2.1",
+                "sebastian/comparator": "^6.3.0",
                 "sebastian/diff": "^6.0.2",
                 "sebastian/environment": "^7.2.0",
                 "sebastian/exporter": "^6.3.0",
@@ -796,7 +796,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.3"
             },
             "funding": [
                 {
@@ -812,7 +812,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-21T05:51:08+00:00"
+            "time": "2025-01-13T09:36:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/doc/tuto_11.md
+++ b/doc/tuto_11.md
@@ -22,7 +22,6 @@ class AttachmentDocument extends PdfDocument
 
 $file = "test/attached.txt";
 
-// instanciation of inherited class
 $pdf = new AttachmentDocument();
 $pdf->addPage();
 $document->attach($file);

--- a/doc/tuto_11.md
+++ b/doc/tuto_11.md
@@ -1,0 +1,50 @@
+# Attachments
+
+Since version `2.0.13`, a trait allows attaching files to the PDF.
+
+**Note:** The code is inspired from this given
+[FPDF script](http://www.fpdf.org/en/script/script95.php) created by
+Oliver.
+
+The `openAttachmentPane()` method is also provided to force the PDF viewer to open
+the attachment pane when the document is loaded.
+
+To use it, create a derived class and use the `PdfAttachmentTrait` trait:
+
+```php
+use fpdf\PdfDocument;
+use fpdf\Traits\PdfAttachmentTrait;
+
+class AttachmentDocument extends PdfDocument
+{
+    use PdfAttachmentTrait;
+}
+
+$file = "test/attached.txt";
+
+// instanciation of inherited class
+$pdf = new AttachmentDocument();
+$pdf->addPage();
+$document->attach($file);
+$document->openAttachmentPane();
+
+$pdf->output();
+```
+
+**Result:**
+
+![Result](http://www.fpdf.org/en/script/ex95.pdf)
+
+**See also:**
+
+- [Minimal example](tuto_1.md)
+- [Header, footer, page break and image](tuto_2.md)
+- [Line breaks and colors](tuto_3.md)
+- [Multi-columns](tuto_4.md)
+- [Tables](tuto_5.md)
+- [Bookmarks](tuto_6.md)
+- [Transparency](tuto_7.md)
+- [Circles and ellipses](tuto_8.md)
+- [Rotation](tuto_9.md)
+- [Sector](tuto_10.md)
+- [Home](../README.md)

--- a/doc/tuto_11.md
+++ b/doc/tuto_11.md
@@ -6,12 +6,10 @@ Since version `2.0.13`, a trait allows attaching files to the PDF.
 [FPDF script](http://www.fpdf.org/en/script/script95.php) created by
 Oliver.
 
-The `openAttachmentPane()` method is also provided to force the PDF viewer to open
-the attachment pane when the document is loaded.
-
 To use it, create a derived class and use the `PdfAttachmentTrait` trait:
 
 ```php
+use fpdf\Enums\PdfPageMode;
 use fpdf\PdfDocument;
 use fpdf\Traits\PdfAttachmentTrait;
 
@@ -20,19 +18,15 @@ class AttachmentDocument extends PdfDocument
     use PdfAttachmentTrait;
 }
 
-$file = "test/attached.txt";
+$file = "attached.txt";
 
 $pdf = new AttachmentDocument();
 $pdf->addPage();
-$document->attach($file);
-$document->openAttachmentPane();
-
+$pdf->attach($file);
+// force the PDF viewer to open the attachment pane
+$pdf->setPageMode(PdfPageMode::USE_ATTACHMENTS);
 $pdf->output();
 ```
-
-**Result:**
-
-![Result](http://www.fpdf.org/en/script/ex95.pdf)
 
 **See also:**
 

--- a/src/Traits/PdfAttachmentTrait.php
+++ b/src/Traits/PdfAttachmentTrait.php
@@ -21,6 +21,8 @@ use fpdf\PdfDocument;
  * The code is inspired from FPDF script
  * <a href="http://www.fpdf.org/en/script/script95.php" target="_blank">Attachment</a>.
  *
+ * @author Andreas Müller <hello@devmount.com>
+ *
  * @phpstan-type PdfAttachedFileType = array{
  *      file: string,
  *      name: string,
@@ -83,11 +85,11 @@ trait PdfAttachmentTrait
     protected function putCatalog(): void
     {
         parent::putCatalog();
-        if (count($this->files) > 0) {
+        if (\count($this->files) > 0) {
             $this->put('/Names <</EmbeddedFiles ' . $this->nFiles . ' 0 R>>');
             $a = [];
             foreach ($this->files as $info) {
-                $a[] = strval($info['n']) . ' 0 R';
+                $a[] = (string) $info['n'] . ' 0 R';
             }
             $this->put('/AF [' . \implode(' ', $a) . ']');
             if ($this->openAttachmentPane) {
@@ -99,7 +101,7 @@ trait PdfAttachmentTrait
     protected function putResources(): void
     {
         parent::putResources();
-        if (count($this->files) > 0) {
+        if (\count($this->files) > 0) {
             $this->putFiles();
         }
     }
@@ -118,10 +120,11 @@ trait PdfAttachmentTrait
             $fc = \file_get_contents($file);
             if (false === $fc) {
                 $this->error('Cannot open file: ' . $file);
+
                 return;
             }
             $size = \strlen($fc);
-            $time = \filemtime($file) ?: time();
+            $time = \filemtime($file) ?: \time();
             $date = @\date('YmdHisO', $time);
             $md = 'D:' . \substr($date, 0, -2) . "'" . \substr($date, -2) . "'";
 
@@ -132,7 +135,7 @@ trait PdfAttachmentTrait
             $this->put('/F (' . $this->escape($name) . ')');
             $this->put('/UF ' . $this->textString($name));
             $this->put('/EF <</F ' . ($this->objectNumber + 1) . ' 0 R>>');
-            if ($desc !== '') {
+            if ('' !== $desc) {
                 $this->put('/Desc ' . $this->textString($desc));
             }
             $this->put('/AFRelationship /Unspecified');
@@ -155,7 +158,7 @@ trait PdfAttachmentTrait
         $this->nFiles = $this->objectNumber;
         $a = [];
         foreach ($this->files as $i => $info) {
-            $a[] = $this->textString(\sprintf('%03d', $i)) . ' ' . strval($info['n']) . ' 0 R';
+            $a[] = $this->textString(\sprintf('%03d', $i)) . ' ' . (string) $info['n'] . ' 0 R';
         }
         $this->put('<<');
         $this->put('/Names [' . \implode(' ', $a) . ']');

--- a/src/Traits/PdfAttachmentTrait.php
+++ b/src/Traits/PdfAttachmentTrait.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of the 'fpdf' package.
+ *
+ * For the license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Andreas Müller <hello@devmount.com>
+ */
+
+declare(strict_types=1);
+
+namespace fpdf\Traits;
+
+use Exception;
+
+/**
+ * Trait to add file attachment support.
+ *
+ * The code is inspired from FPDF script
+ * <a href="http://www.fpdf.org/en/script/script95.php" target="_blank">Attachment</a>.
+ * 
+ * @phpstan-type PdfAttachedFileType = array{
+ *      file: string,
+ *      name: string,
+ *      desc: string}
+ *
+ * @phpstan-require-extends PdfDocument
+ */
+trait PdfAttachmentTrait
+{
+    /**
+     * The attached files.
+     *
+     * @phpstan-var PdfAttachedFileType[]
+     */
+    private array $files = [];
+
+    /**
+     * The files object number.
+     */
+    private int $nFiles;
+
+    /**
+     * Flag to open the attachment pane in a PDF reader per default
+     */
+    private bool $openAttachmentPane = false;
+
+        
+    /**
+     * Attaches a given file to the PDF document.
+     *
+     * @param  string $file Path to the file to be attached.
+     * @param  string $name Optional alternative file name to be used for the attachment.
+     * @param  string $desc Optional description for the file contents.
+     * @return static
+     */
+    public function attach(string $file, string $name = '', string $desc = ''): static
+    {
+        if ($name == '') {
+            $p = strrpos($file, '/');
+            if ($p === false) {
+                $p = strrpos($file, '\\');
+            }
+            if ($p !== false) {
+                $name = substr($file, $p + 1);
+            }
+            else {
+                $name = $file;
+            }
+        }
+        $this->files[] = ['file' => $file, 'name' => $name, 'desc' => $desc];
+        return $this;
+    }
+
+    
+    /**
+     * Opens the attachment pane in PDF readers that support it.
+     *
+     * @return static
+     */
+    public function openAttachmentPane(): static
+    {
+        $this->openAttachmentPane = true;
+        return $this;
+    }
+
+    private function putFiles()
+    {
+        foreach ($this->files as $i => &$info) {
+            $file = $info['file'];
+            $name = $info['name'];
+            $desc = $info['desc'];
+
+            $fc = file_get_contents($file);
+            if ($fc === false) {
+                $this->error('Cannot open file: ' . $file);
+            }
+            $size = strlen($fc);
+            $date = @date('YmdHisO', filemtime($file));
+            $md = 'D:' . substr($date, 0, -2) . "'" . substr($date, -2) . "'";;
+
+            $this->putNewObj();
+            $info['n'] = $this->objectNumber;
+            $this->put('<<');
+            $this->put('/Type /Filespec');
+            $this->put('/F (' . $this->escape($name) . ')');
+            $this->put('/UF ' . $this->textstring($name));
+            $this->put('/EF <</F ' . ($this->objectNumber + 1) . ' 0 R>>');
+            if ($desc) {
+                $this->put('/Desc ' . $this->textstring($desc));
+            }
+            $this->put('/AFRelationship /Unspecified');
+            $this->put('>>');
+            $this->put('endobj');
+
+            $this->putNewObj();
+            $this->put('<<');
+            $this->put('/Type /EmbeddedFile');
+            $this->put('/Subtype /application#2Foctet-stream');
+            $this->put('/Length ' . $size);
+            $this->put('/Params <</Size ' . $size . ' /ModDate ' . $this->textstring($md) . '>>');
+            $this->put('>>');
+            $this->putstream($fc);
+            $this->put('endobj');
+        }
+        unset($info);
+
+        $this->putNewObj();
+        $this->nFiles = $this->objectNumber;
+        $a = array();
+        foreach ($this->files as $i => $info) {
+            $a[] = $this->textstring(sprintf('%03d', $i)) . ' ' . $info['n'] . ' 0 R';
+        }
+        $this->put('<<');
+        $this->put('/Names [' . implode(' ', $a) . ']');
+        $this->put('>>');
+        $this->put('endobj');
+    }
+
+    protected function putResources(): void
+    {
+        parent::putResources();
+        if (!empty($this->files)) {
+            $this->putFiles();
+        }
+    }
+
+    protected function putCatalog(): void
+    {
+        parent::putCatalog();
+        if (!empty($this->files)) {
+            $this->put('/Names <</EmbeddedFiles ' . $this->nFiles . ' 0 R>>');
+            $a = array();
+            foreach ($this->files as $info) {
+                $a[] = $info['n'] . ' 0 R';
+            }
+            $this->put('/AF [' . implode(' ', $a) . ']');
+            if ($this->openAttachmentPane) {
+                $this->put('/PageMode /UseAttachments');
+            }
+        }
+    }
+
+    private function error(string $msg)
+    {
+        // Fatal error
+        throw new Exception('FPDF2 error: ' . $msg);
+    }
+}

--- a/src/Traits/PdfAttachmentTrait.php
+++ b/src/Traits/PdfAttachmentTrait.php
@@ -121,7 +121,7 @@ trait PdfAttachmentTrait
             }
             $size = \strlen($fc);
             $time = false !== \filemtime($file) ? \filemtime($file) : \time();
-            $date = @\date('YmdHisO', $time);
+            $date = \date('YmdHisO', $time);
             $md = 'D:' . \substr($date, 0, -2) . "'" . \substr($date, -2) . "'";
 
             $this->putNewObj();

--- a/src/Traits/PdfAttachmentTrait.php
+++ b/src/Traits/PdfAttachmentTrait.php
@@ -134,7 +134,7 @@ trait PdfAttachmentTrait
             $this->put('/Type /Filespec');
             $this->put('/F (' . $this->escape($name) . ')');
             $this->put('/UF ' . $this->textString($name));
-            $this->put('/EF <</F ' . ($this->objectNumber + 1) . ' 0 R>>');
+            $this->put('/EF <</F ' . (string) ($this->objectNumber + 1) . ' 0 R>>');
             if ('' !== $desc) {
                 $this->put('/Desc ' . $this->textString($desc));
             }
@@ -146,8 +146,8 @@ trait PdfAttachmentTrait
             $this->put('<<');
             $this->put('/Type /EmbeddedFile');
             $this->put('/Subtype /application#2Foctet-stream');
-            $this->put('/Length ' . $size);
-            $this->put('/Params <</Size ' . $size . ' /ModDate ' . $this->textString($md) . '>>');
+            $this->put('/Length ' . (string) $size);
+            $this->put('/Params <</Size ' . (string) $size . ' /ModDate ' . $this->textString($md) . '>>');
             $this->put('>>');
             $this->putStream($fc);
             $this->put('endobj');

--- a/src/Traits/PdfAttachmentTrait.php
+++ b/src/Traits/PdfAttachmentTrait.php
@@ -42,7 +42,7 @@ trait PdfAttachmentTrait
     /**
      * The attached files.
      *
-     * @phpstan-var PdfAttachedFileType[]
+     * @phpstan-var array<int, PdfAttachedFileType>
      */
     private array $attachments = [];
 

--- a/src/Traits/PdfAttachmentTrait.php
+++ b/src/Traits/PdfAttachmentTrait.php
@@ -61,11 +61,7 @@ trait PdfAttachmentTrait
     public function attach(string $file, string $name = '', string $desc = ''): static
     {
         if ('' === $name) {
-            $p = \strrpos($file, '/');
-            if (false === $p) {
-                $p = \strrpos($file, '\\');
-            }
-            $name = false !== $p ? \substr($file, $p + 1) : $file;
+            $name = \basename($file);
         }
         $this->files[] = ['file' => $file, 'name' => $name, 'desc' => $desc, 'n' => -1];
 

--- a/src/Traits/PdfAttachmentTrait.php
+++ b/src/Traits/PdfAttachmentTrait.php
@@ -52,7 +52,8 @@ trait PdfAttachmentTrait
      * Attaches a given file to the PDF document.
      *
      * @param  string $file Path to the file to be attached.
-     * @param  string $name Optional alternative file name to be used for the attachment.
+     * @param  string $name Optional alternative file name to be used for the attachment. The default value is taken
+     *                      from $file.
      * @param  string $desc Optional description for the file contents.
      * @return static
      */
@@ -76,7 +77,7 @@ trait PdfAttachmentTrait
 
     
     /**
-     * Opens the attachment pane in PDF readers that support it.
+     * Forces the attachment pane to open in PDF viewers that support it.
      *
      * @return static
      */

--- a/src/Traits/PdfAttachmentTrait.php
+++ b/src/Traits/PdfAttachmentTrait.php
@@ -86,7 +86,7 @@ trait PdfAttachmentTrait
     {
         parent::putCatalog();
         if (\count($this->files) > 0) {
-            $this->put('/Names <</EmbeddedFiles ' . $this->nFiles . ' 0 R>>');
+            $this->put('/Names <</EmbeddedFiles ' . (string) $this->nFiles . ' 0 R>>');
             $a = [];
             foreach ($this->files as $info) {
                 $a[] = (string) $info['n'] . ' 0 R';
@@ -114,8 +114,8 @@ trait PdfAttachmentTrait
 
     private function putFiles(): void
     {
-        foreach ($this->files as $i => &$info) {
-            [$file, $name, $desc] = $info;
+        foreach ($this->files as &$info) {
+            ['file' => $file, 'name' => $name, 'desc' => $desc] = $info;
 
             $fc = \file_get_contents($file);
             if (false === $fc) {
@@ -124,7 +124,7 @@ trait PdfAttachmentTrait
                 return;
             }
             $size = \strlen($fc);
-            $time = \filemtime($file) ?: \time();
+            $time = false !== \filemtime($file) ? \filemtime($file) : \time();
             $date = @\date('YmdHisO', $time);
             $md = 'D:' . \substr($date, 0, -2) . "'" . \substr($date, -2) . "'";
 
@@ -149,7 +149,7 @@ trait PdfAttachmentTrait
             $this->put('/Length ' . $size);
             $this->put('/Params <</Size ' . $size . ' /ModDate ' . $this->textString($md) . '>>');
             $this->put('>>');
-            $this->putstream($fc);
+            $this->putStream($fc);
             $this->put('endobj');
         }
         unset($info);

--- a/tests/Traits/PdfAttachmentTraitTest.php
+++ b/tests/Traits/PdfAttachmentTraitTest.php
@@ -6,7 +6,7 @@
  * For the license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author bibi.nu <bibi@bibi.nu>
+ * @author Andreas Müller <hello@devmount.com>
  */
 
 declare(strict_types=1);

--- a/tests/Traits/PdfAttachmentTraitTest.php
+++ b/tests/Traits/PdfAttachmentTraitTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the 'fpdf' package.
+ *
+ * For the license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author bibi.nu <bibi@bibi.nu>
+ */
+
+declare(strict_types=1);
+
+namespace fpdf\Tests\Traits;
+
+use fpdf\Enums\PdfDestination;
+use fpdf\PdfDocument;
+use fpdf\Traits\PdfAttachmentTrait;
+use PHPUnit\Framework\TestCase;
+
+class PdfAttachmentTraitTest extends TestCase
+{
+    public function testNoAttachments(): void
+    {
+        $document = new class() extends PdfDocument {
+            use PdfAttachmentTrait;
+        };
+        $document->addPage();
+        $document->output(PdfDestination::STRING);
+        self::assertSame(1, $document->getPage());
+    }
+
+    public function testAttachment(): void
+    {
+        $document = new class() extends PdfDocument {
+            use PdfAttachmentTrait;
+        };
+        $document->addPage();
+        $document->attach('tests/resources/attachment.txt');
+        $document->openAttachmentPane();
+        $document->output(PdfDestination::STRING);
+        self::assertSame(1, $document->getPage());
+    }
+}

--- a/tests/Traits/PdfAttachmentTraitTest.php
+++ b/tests/Traits/PdfAttachmentTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the 'fpdf' package.
  *

--- a/tests/Traits/PdfAttachmentTraitTest.php
+++ b/tests/Traits/PdfAttachmentTraitTest.php
@@ -20,16 +20,6 @@ use PHPUnit\Framework\TestCase;
 
 class PdfAttachmentTraitTest extends TestCase
 {
-    public function testNoAttachments(): void
-    {
-        $document = new class() extends PdfDocument {
-            use PdfAttachmentTrait;
-        };
-        $document->addPage();
-        $document->output(PdfDestination::STRING);
-        self::assertSame(1, $document->getPage());
-    }
-
     public function testAttachment(): void
     {
         $document = new class() extends PdfDocument {
@@ -38,6 +28,16 @@ class PdfAttachmentTraitTest extends TestCase
         $document->addPage();
         $document->attach('tests/resources/attachment.txt');
         $document->openAttachmentPane();
+        $document->output(PdfDestination::STRING);
+        self::assertSame(1, $document->getPage());
+    }
+
+    public function testNoAttachments(): void
+    {
+        $document = new class() extends PdfDocument {
+            use PdfAttachmentTrait;
+        };
+        $document->addPage();
         $document->output(PdfDestination::STRING);
         self::assertSame(1, $document->getPage());
     }

--- a/tests/Traits/PdfAttachmentTraitTest.php
+++ b/tests/Traits/PdfAttachmentTraitTest.php
@@ -1,12 +1,11 @@
 <?php
-
 /*
  * This file is part of the 'fpdf' package.
  *
  * For the license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author Andreas Müller <hello@devmount.com>
+ * @author bibi.nu <bibi@bibi.nu>
  */
 
 declare(strict_types=1);

--- a/tests/Traits/PdfAttachmentTraitTest.php
+++ b/tests/Traits/PdfAttachmentTraitTest.php
@@ -26,13 +26,12 @@ class PdfAttachmentTraitTest extends TestCase
             use PdfAttachmentTrait;
         };
         $document->addPage();
-        $document->attach('tests/resources/attachment.txt');
-        $document->openAttachmentPane();
+        $document->attach(__DIR__ . '/../resources/attachment.txt');
         $document->output(PdfDestination::STRING);
         self::assertSame(1, $document->getPage());
     }
 
-    public function testNoAttachments(): void
+    public function testNoAttachment(): void
     {
         $document = new class() extends PdfDocument {
             use PdfAttachmentTrait;

--- a/tests/Traits/PdfTransparencyTraitTest.php
+++ b/tests/Traits/PdfTransparencyTraitTest.php
@@ -18,6 +18,11 @@ use fpdf\PdfDocument;
 use fpdf\Traits\PdfTransparencyTrait;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * PdfTransparencyTraitTest.
+ *
+ * @author Andreas Müller <hello@devmount.com>
+ */
 class PdfTransparencyTraitTest extends TestCase
 {
     public function testEmptyTransparency(): void

--- a/tests/Traits/PdfTransparencyTraitTest.php
+++ b/tests/Traits/PdfTransparencyTraitTest.php
@@ -18,11 +18,6 @@ use fpdf\PdfDocument;
 use fpdf\Traits\PdfTransparencyTrait;
 use PHPUnit\Framework\TestCase;
 
-/**
- * PdfTransparencyTraitTest.
- *
- * @author Andreas Müller <hello@devmount.com>
- */
 class PdfTransparencyTraitTest extends TestCase
 {
     public function testEmptyTransparency(): void

--- a/tests/resources/attachment.txt
+++ b/tests/resources/attachment.txt
@@ -1,0 +1,1 @@
+This file is meant to be attached to a PDF file.

--- a/vendor-bin/php-cs-fixer/composer.lock
+++ b/vendor-bin/php-cs-fixer/composer.lock
@@ -406,16 +406,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.67.0",
+            "version": "v3.68.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "0ad34c75d1172f7d30320460e803887981830cbf"
+                "reference": "73f78d8b2b34a0dd65fedb434a602ee4c2c8ad4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/0ad34c75d1172f7d30320460e803887981830cbf",
-                "reference": "0ad34c75d1172f7d30320460e803887981830cbf",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/73f78d8b2b34a0dd65fedb434a602ee4c2c8ad4c",
+                "reference": "73f78d8b2b34a0dd65fedb434a602ee4c2c8ad4c",
                 "shasum": ""
             },
             "require": {
@@ -497,7 +497,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.67.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.68.0"
             },
             "funding": [
                 {
@@ -505,7 +505,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-08T10:17:40+00:00"
+            "time": "2025-01-13T17:01:01+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
This PR offers a trait to add file attachments to PDF files.

It can be used similar to the already existing traits:

```php
use fpdf\PdfDocument;
use fpdf\Traits\PdfAttachmentTrait;

class AttachmentDocument extends PdfDocument
{
    use PdfAttachmentTrait;
}

$file = "test/attached.txt";

$pdf = new AttachmentDocument();
$pdf->addPage();
$document->attach($file);
$document->openAttachmentPane();

$pdf->output();
```

It also provides tests and documentation for this trait.

Fixes #4 